### PR TITLE
as68 : fix error where swapw called with wrong args

### DIFF
--- a/as68/cpy.c
+++ b/as68/cpy.c
@@ -90,7 +90,7 @@ DO_XREF:
 #ifndef XTC68
 	output( (char *)&segval , 2, 1);
 #else
-	output( swapw((char *)&segval, 2) , 2, 1);
+	output( swapw((char *)&segval, 1) , 2, 1);
 #endif
 	c = 0xFB;
 	output(&c,1,1);

--- a/as68/sym.c
+++ b/as68/sym.c
@@ -277,7 +277,7 @@ putsym(p)
 #ifndef XTC68
           output((char *)&len, 2, 1);
 #else
-          output(swapw((char *)&len, 2), 2, 1);
+          output(swapw((char *)&len, 1), 2, 1);
 #endif
         }
     if (! p->name.stix[0] ) {


### PR DESCRIPTION
The second argument for swapw is the number of words to be swapped, but
in both these cases the variable being swapped was a short and only
therefor 1 word. This fixes *** stack smashing detected *** errors
in as68.

Signed-off-by: Graeme Gregory <graeme@xora.org.uk>