### PR TITLE
fix Ubuntu's anally unhelpful warnings, sometimes in expedient but obscure ways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+DIRS = as68  c68  cc  cpp  ld  slb
+CLEANDIRS = $(DIRS:%=clean-%)
+
+all: $(DIRS)
+$(DIRS):
+	$(MAKE) -C $@
+
+clean: $(CLEANDIRS)
+
+$(CLEANDIRS):
+	$(MAKE) -C $(@:clean-%=%) clean
+
+install:
+	@echo
+	@echo "**** You can use move.pl to install in /usr/local ****"
+
+.PHONY: subdirs $(DIRS)
+.PHONY: subdirs $(CLEANDIRS)
+.PHONY: all clean
+

--- a/cc/cc.c
+++ b/cc/cc.c
@@ -1524,12 +1524,12 @@ ASM_PASS:
 					 */
 					if (0 < (fd = open(inname,O_RDONLY)))
 					{
-						(void) read (fd, &ch, 1);
-						(void) close (fd);
-						if ('#' == ch)
-						{
-							goto X_FILE;
-						}
+                                            int n = read (fd, &ch, 1);
+                                            close (fd); 
+                                            if (n == 1 && '#' == ch)
+                                            {
+                                                goto X_FILE;
+                                            }
 					}
 				}
 				break;

--- a/cc/ccutil.c
+++ b/cc/ccutil.c
@@ -818,7 +818,7 @@ void	printstr ( char * str, ...)
 		}
 		else
 #else
-		(void) write( STDERR_FILENO, str, strlen(str));
+                    if(write( STDERR_FILENO, str, strlen(str))); // shut up Ubuntu's compiler
 #endif
 		str = (char *)va_arg(ap, char *);
 	}

--- a/cpp/cccp.c
+++ b/cpp/cccp.c
@@ -2935,8 +2935,8 @@ void special_symbol ( HASHNODE *hp, FILE_BUF *op)
       if (instack[i].fname != NULL)
         true_indepth++;
 
-    buf = (char *) alloca (8);	/* Eigth bytes ought to be more than enough */
-    sprintf (buf, "%d", true_indepth - 1);
+    buf = (char *) alloca (16);	/* Eigth bytes ought to be more than enough jh: but not for the compiler ... */
+    sprintf (buf, "%ld", true_indepth - 1);
     break;
 
   case T_VERSION:
@@ -2946,12 +2946,12 @@ void special_symbol ( HASHNODE *hp, FILE_BUF *op)
 
   case T_CONST:
     buf = (char *) alloca (4 * sizeof (long));
-    sprintf (buf, "%d", hp->value.ival);
+    sprintf (buf, "%ld", hp->value.ival);
     break;
 
   case T_SPECLINE:
     buf = (char *) alloca (10);
-    sprintf (buf, "%d", ip->lineno);
+    sprintf (buf, "%ld", ip->lineno);
     break;
 
   case T_DATE:
@@ -4119,7 +4119,7 @@ void do_elif (U_CHAR *buf, U_CHAR *limit, FILE_BUF *op)
   } else {
     if (if_stack->type != T_IF && if_stack->type != T_ELIF) {
       error ("#elif after #else");
-      fprintf (stderr, " (matches line %d", if_stack->lineno);
+      fprintf (stderr, " (matches line %ld", if_stack->lineno);
       if (if_stack->fname != NULL && ip->fname != NULL &&
 	  strcmp (if_stack->fname, ip->fname) != 0)
 	fprintf (stderr, ", file %s", if_stack->fname);
@@ -4404,7 +4404,7 @@ void do_else (U_CHAR *buf, U_CHAR *limit, FILE_BUF *op)
   } else {
     if (if_stack->type != T_IF && if_stack->type != T_ELIF) {
       error ("#else after #else");
-      fprintf (stderr, " (matches line %d", if_stack->lineno);
+      fprintf (stderr, " (matches line %ld", if_stack->lineno);
       if (strcmp (if_stack->fname, ip->fname) != 0)
 	fprintf (stderr, ", file %s", if_stack->fname);
       fprintf (stderr, ")\n");
@@ -4904,7 +4904,7 @@ void macroexpand (HASHNODE *hp, FILE_BUF *op)
 	    if (isprint (c))
 	      xbuf[totlen++] = c;
 	    else {
-              sprintf ((char *) &xbuf[totlen], "\\%03o", (unsigned long) c);
+              sprintf ((char *) &xbuf[totlen], "\\%03lo", (unsigned long) c);
 	      totlen += 4;
 	    }
 	  }
@@ -5342,7 +5342,7 @@ int error (char *msg,...)
     }
 
   if (ip != NULL)
-    fprintf (stderr, "%s:%d: ", ip->fname, ip->lineno);
+    fprintf (stderr, "%s:%ld: ", ip->fname, ip->lineno);
   vfprintf (stderr, msg, arg);
   fprintf (stderr, "\n");
   errors++;
@@ -5363,7 +5363,7 @@ int error_from_errno (char *name)
     }
 
   if (ip != NULL)
-    fprintf (stderr, "%s:%d: ", ip->fname, ip->lineno);
+    fprintf (stderr, "%s:%ld: ", ip->fname, ip->lineno);
 
 #ifdef QDOS
   if ((errno < sys_nerr) && (errno != -1))
@@ -5398,7 +5398,7 @@ int warning (char *msg,...)
 }
 
   if (ip != NULL)
-    fprintf (stderr, "%s:%d: ", ip->fname, ip->lineno);
+    fprintf (stderr, "%s:%ld: ", ip->fname, ip->lineno);
   fprintf (stderr, "warning: ");
   vfprintf (stderr, msg, va);
   fprintf (stderr, "\n");
@@ -5418,7 +5418,7 @@ int error_with_line (long line, char *msg,...)
   }
 
   if (ip != NULL)
-    fprintf (stderr, "%s:%d: ", ip->fname, line);
+    fprintf (stderr, "%s:%ld: ", ip->fname, line);
   vfprintf (stderr, msg, va);
   fprintf (stderr, "\n");
   errors++;

--- a/ld/ldold.c
+++ b/ld/ldold.c
@@ -294,7 +294,7 @@ void halt(int n,...)
          long npos;
          npos = (long)(lseek (inp_hnd, 0, SEEK_CUR)-(buf_end-buf_ptr));
 
-        (void) fprintf (stderr,"(file='%s', position = %ld (%x))\n",
+        (void) fprintf (stderr,"(file='%s', position = %ld (%lx))\n",
                         currentname, npos, npos);
         }
 #else
@@ -319,7 +319,7 @@ void statistic(void)
    (void) fprintf(list_file,"---------------------------\n");
    for (s=sec_liste;s!=NULL;s=s->sec_next)
       (void) fprintf(list_file,
-         "%-9s %8lX %8lX\n",s->sec_name,s->sec_start-membot,s->sec_length);
+         "%-9s %8X %8lX\n",s->sec_name,s->sec_start-membot,s->sec_length);
    fprintf(list_file,"---------------------------\n");
 }
 
@@ -459,7 +459,7 @@ void list_xsy(XSYMBOL  *xsy_liste, int      u_flag)
          if (xsy_liste->xsy_defd&1)
          {
             fprintf(list_file,
-               "%-20s %08X%c",xsy_liste->xsy_name,calc_xsy(xsy_liste),
+               "%-20s %08lX%c",xsy_liste->xsy_name,calc_xsy(xsy_liste),
                   xsy_liste->xsy_defd&2?' ':'*');
             if (xsy_liste->xsy_sect!=NULL)
                fprintf(list_file," %15s",xsy_liste->xsy_sect->sec_name);
@@ -621,7 +621,7 @@ void nxsy(void)
                         sy.length=1;
                         sy.data_byte=0xFB;
                         break;
-         default     :  printf("Illegal Directive $%02.2x\n", ch); halt(2);
+         default     :  printf("Illegal Directive $%02x\n", ch); halt(2);
                         break;
       }
    }
@@ -1042,7 +1042,7 @@ void module(void)
       if (lstng_flag)
       {
          if (i++>3) { fprintf(list_file,"\n"); i=0; }
-         fprintf(list_file," %8.8s=%08X",
+         fprintf(list_file," %8.8s=%08lX",
                  sec->sec_name,sec->sec_length-sec->sec_oldlen);
       }
       sec->sec_oldlen=sec->sec_length;
@@ -1478,9 +1478,9 @@ void write_prog(void)
       }
    }
 	if(psize & 1)
-		{/* Write an extra byte of zero to even up the program file */
-		write(handle,&c,1);
-		}
+        {/* Write an extra byte of zero to even up the program file */
+            if(write(handle,&c,1)); // shut up ubuntu compiler ...
+        }
    /* Read the QDOS header information */
    bss_size -= (endcode - start );
 #ifdef QDOS
@@ -1501,9 +1501,9 @@ void write_prog(void)
 #ifdef XTC68
     {
        char x[4];
-       write(handle, "XTcc", 4);
+       if(write(handle, "XTcc", 4));
        out_long(x, dspace);
-       write(handle, x, 4);
+       if(write(handle, x, 4));
 #ifdef __unix__
        fchmod(handle, S_IRUSR |S_IWUSR);
 #endif
@@ -1777,9 +1777,9 @@ int main(int   argc, char  **argv)
        fprintf(list_file,"Relocation table = %8X\n",code_ptr-debug_end);
        fprintf(list_file,"--------------------\n");
        fprintf(list_file,
-          "Memory Usage     = %7d%%\n",(code_ptr-membot)*100/mem_size);
+          "Memory Usage     = %7ld%%\n",(code_ptr-membot)*100/mem_size);
        fprintf(list_file,
-          "Buffer Usage     = %7d%%\n",(module_max-module_buffer)*100/buf_size);
+          "Buffer Usage     = %7ld%%\n",(module_max-module_buffer)*100/buf_size);
        fprintf(list_file,"--------------------\n");
     }
    list_xsy(xsy_ll,1);

--- a/makeall
+++ b/makeall
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for D in c68 cc cpp as68 ld slb
-do
- cd $D
- make $@
- cd ..
-done

--- a/slb/slbanal.c
+++ b/slb/slbanal.c
@@ -69,7 +69,7 @@ char    *text;
     char    idstr[20];
 
     DBG(("ADD_ID",0x1001,"Enter: id=%04.4x, text='%s'",id,text));
-    sprintf (idstr,"%04.4x",((unsigned)id & 0xFFFF));
+    sprintf (idstr,"%04x",((unsigned)id & 0xFFFF));
     if (! (ptr=(IDPTR)Find_Node((NODEPTR)IdTree,idstr))) {
         ptr=(IDPTR)Add_Node ((NODEBASE)&IdTree,OwnerNode,idstr,sizeof(IDSTRUCT));
     }
@@ -97,12 +97,12 @@ short   id;
         return ("PC");
     }
 
-    sprintf(buffer,"%04.4x",((unsigned)id & 0xFFFF));
+    sprintf(buffer,"%04x",((unsigned)id & 0xFFFF));
     if (ptr = (IDPTR)Find_Node((NODEPTR)IdTree,buffer)) {
         DBG(("FIND_ID",0x801,"Exit: Node name='%s'",ptr->name));
         return (ptr->name);
     }
-    sprintf (buffer,"Id=$%04.4x",id);
+    sprintf (buffer,"Id=$%04x",id);
     DBG(("FIND_ID",0x801,"Exit: '%s'",buffer));
     return (buffer);              
 }
@@ -140,7 +140,7 @@ char  * Get_LongWord()
                     + (inchar(libfp) << 16) 
                     + (inchar(libfp) << 8) 
                     + inchar(libfp));
-    sprintf (LongText,"$%08.8x",LongWord);
+    sprintf (LongText,"$%08lx",LongWord);
     DBG(("GET_LONGWORD",0xF01,"%s",LongText));
     return (LongText);
 }
@@ -161,7 +161,7 @@ char    *buffer;
     case '-':
             if (Op != ' ')  *buffer++ = Op;
             Op = (char)ch;
-            sprintf (buffer,Get_Id());
+            strcpy (buffer,Get_Id());
             Get_Op(&buffer[strlen(buffer)]);
             break;
     default:

--- a/slb/slbdis.c
+++ b/slb/slbdis.c
@@ -240,7 +240,7 @@ int     size;
         default:
             DBG (("GET_DATA",0x88,"$%02.2x character",ch));
             reply = (reply << 8) + (ch & 0xFF);
-            sprintf (buffer,"%02.2x",ch & 0xFF);
+            sprintf (buffer,"%02x",ch & 0xFF);
             strcat (databuf,buffer);
             size--;
             break;
@@ -536,7 +536,7 @@ void    Long_Label(char sep)
           value = (value << 16)
                    + (inchar(libfp) << 8)
                    + (inchar(libfp));
-          sprintf (buffer,"%08.8x",value);
+          sprintf (buffer,"%08lx",value);
           DBG(("LONG_LABEL",0x408,"... data=%s",buffer));
           strcat(databuf,buffer);
           symbolic (value, sep);

--- a/slb/slbmodul.c
+++ b/slb/slbmodul.c
@@ -167,7 +167,7 @@ FILE * lstfp;
     incount = 0;
     if (lstfp) {
         if (nflag) {
-            sprintf (filename, "%03.3d_",nflag);
+            sprintf (filename, "%03d_",nflag);
             if (newfp || lstfp)    nflag++;
         } else
             filename[0] = '\0';


### PR DESCRIPTION
This PR fixes all compiler warnings on Ubuntu. It doesn't improve the code, it just silences Ubuntu's annoying pedantry (shock horror, pot calls kettle 'black' (in a PC way)). Wish I hadn't start this meme ...

And use a top level Makefile for good measure. 