### PR TITLE
install.sh : add missing $ for variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ do
   case $FN in
     */include_*)
       IFILE=${FN##*include_}
-      case IFILE in
+      case $IFILE in
 	sys_*)
 	  SIFILE=${IFILE##*sys_}
 	  $CP $FILE /usr/local/qdos/include/sys/$SIFILE


### PR DESCRIPTION
The missing $ on IFILE in case statement makes sys/ include files
install in the wrong directory.

Signed-off-by: Graeme Gregory <graeme@xora.org.uk>