### PR TITLE
ld/Makefile : define -fsigned-char for all platforms.

### DIFF
--- a/ld/Makefile
+++ b/ld/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJS = ld.o
 
 # We force an ia32 application to avoid having to fix numerous long assumptions
-CFLAGS = -DXTC68 -O2
+CFLAGS = -DXTC68 -O2 -fsigned-char
 LDFLAGS =
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),x86_64)


### PR DESCRIPTION
ld needs signed char as it uses negative numbers in case statments that
otherwise become high postive numbers because it uses char type.

x86 char is by default signed in gcc
arm char is by default unsigned in gcc

Signed-off-by: Graeme Gregory <graeme@xora.org.uk>